### PR TITLE
use gcc 13 for c++

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,13 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 	libsqlite3-dev libcurl4-openssl-dev libhiredis-dev \
 	gettext luajit ocaml opam swi-prolog
 
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y \
+        && apt-get update \
+        && apt-get upgrade \
+        && apt-get install -y gcc-13 g++-13 \
+        && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
+        && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+
 # The games path is used by fortune and cowsay:
 ENV PATH "${PATH}:/usr/games"
 


### PR DESCRIPTION
I don't know if we should do `apt-get update` and `apt-get upgrade` after adding a new apt repository. If it's not necessary, feel free to remove it ;)